### PR TITLE
First pass at Terraform for Azure AI provision and bind

### DIFF
--- a/azure-ai-model.yml
+++ b/azure-ai-model.yml
@@ -3,7 +3,7 @@
 ---
 version: 1
 name: csb-azure-ai-model
-id: 12345678-1234-1234-1234-1234567890ab
+id: 2b89aa85-00c8-4507-a74b-c8f7ce95bf27
 description: Manage Azure AI Models
 display_name: Azure AI Model
 image_url: file://service-images/csb.png
@@ -12,104 +12,112 @@ support_url: https://support.microsoft.com/en-us/azure
 tags: [azure, ai, model, preview]
 plan_updateable: true
 plans:
-- name: basic
-  id: 87654321-4321-4321-4321-0987654321ba
-  description: 'Basic plan for Azure AI Model'
-  display_name: "Basic"
-  properties:
-    model_name: "default-model"
-    model_version: "latest"
+  - name: basic
+    id: d9575f01-1d5b-4196-bea8-e0d59b6ccfd9
+    description: "Basic plan for Azure AI Model"
+    display_name: "Basic"
+    properties:
+      model_name: "default-model"
+      model_version: "latest"
 provision:
-  plan_inputs: []
+  plan_inputs:
   user_inputs:
-  - field_name: location
-    type: string
-    default: eastus
-    details: The region to create the service in
-    constraints:
-      pattern: "^[a-zA-Z0-9-]+$"
-  - field_name: model_name
-    type: string
-    details: The name of the AI model
-    required: true
-  - field_name: model_version
-    type: string
-    default: latest
-    details: The version of the AI model
-  - field_name: api_key
-    type: string
-    details: The API key for accessing the AI model
-    required: true
-  - field_name: azure_tenant_id
-    type: string
-    details: Azure Tenant to create resource in
-    default: ${config("azure.tenant_id")}
-  - field_name: azure_subscription_id
-    type: string
-    details: Azure Subscription to create resource in
-    default: ${config("azure.subscription_id")}
-  - field_name: azure_client_id
-    type: string
-    details: Client ID of Azure principal
-    default: ${config("azure.client_id")}
-  - field_name: azure_client_secret
-    type: string
-    details: Client secret for Azure principal
-    default: ${config("azure.client_secret")}
+    - field_name: location
+      type: string
+      default: eastus
+      details: The region to create the service in
+      constraints:
+        pattern: "^[a-zA-Z0-9-]+$"
+    - field_name: model_name
+      type: string
+      details: The name of the AI model. Valid options are `o1-preview`, `o1-mini`, `gpt-4o`, `gpt-4o-mini`. The full list of models that are supported by Azure (but not necessarily supported yet by this brokerpak) is found in the [Azure Documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models).
+      required: true
+    - field_name: model_version
+      type: string
+      default: latest
+      details: |
+        The version of the AI model. Valid versions for each model are:
+
+        - `o1-preview`: `2024-09-12`
+        - `o1-mini`: `2024-09-12`
+        - `gpt-4o`: `2024-11-20`, `2024-08-06`, `2024-05-13`
+        - `gpt-4o-mini`: `2024-07-18`
   computed_inputs:
-  - name: labels
-    default: ${json.marshal(request.default_labels)}
-    overwrite: true
-    type: object
-outputs:
-  - field_name: service_name
-    type: string
-    details: The name of the Azure AI service
-  - field_name: model_name
-    type: string
-    details: The name of the AI model
-  - field_name: model_version
-    type: string
-    details: The version of the AI model
-  - field_name: api_key
-    type: string
-    details: The API key for accessing the AI model
-  - field_name: endpoint_url
-    type: string
-    details: The constructed endpoint URL for the AI model
-bind:
-  plan_inputs: []
-  user_inputs: []
-  computed_inputs:
-  - name: model_name
-    type: string
-    default: ${instance.details["model_name"]}
-    overwrite: true
-  - name: model_version
-    type: string
-    default: ${instance.details["model_version"]}
-    overwrite: true
-  - name: api_key
-    type: string
-    default: ${instance.details["api_key"]}
-    overwrite: true
+    - name: labels
+      default: ${json.marshal(request.default_labels)}
+      overwrite: true
+      type: object
+    - name: azure_tenant_id
+      type: string
+      details: Azure Tenant to create resource in
+      default: ${config("azure.tenant_id")}
+    - name: azure_subscription_id
+      type: string
+      details: Azure Subscription to create resource in
+      default: ${config("azure.subscription_id")}
+    - name: azure_client_id
+      type: string
+      details: Client ID of Azure principal
+      default: ${config("azure.client_id")}
+    - name: azure_client_secret
+      type: string
+      details: Client secret for Azure principal
+      default: ${config("azure.client_secret")}
   outputs:
-  - field_name: model_name
-    type: string
-    details: The name of the AI model
-  - field_name: model_version
-    type: string
-    details: The version of the AI model
-  - field_name: api_key
-    type: string
-    details: The API key for accessing the AI model
-  - field_name: endpoint_url
-    type: string
-    details: The constructed endpoint URL for the AI model
-template_refs:
-  outputs: terraform/azure-ai-model/outputs.tf
-  provider: terraform/azure-ai-model/provider.tf
-  versions: terraform/azure-ai-model/versions.tf
-  variables: terraform/azure-ai-model/variables.tf
-  main: terraform/azure-ai-model/main.tf
-  data: terraform/azure-ai-model/data.tf
+    - field_name: service_name
+      type: string
+      details: The name of the Azure AI service
+    - field_name: model_name
+      type: string
+      details: The name of the AI model
+    - field_name: model_version
+      type: string
+      details: The version of the AI model
+    - field_name: api_key
+      type: string
+      details: The API key for accessing the AI model
+    - field_name: endpoint_url
+      type: string
+      details: The constructed endpoint URL for the AI model
+  template_refs:
+    outputs: terraform/azure-ai-model/provision/outputs.tf
+    provider: terraform/azure-ai-model/provision/provider.tf
+    versions: terraform/azure-ai-model/provision/versions.tf
+    variables: terraform/azure-ai-model/provision/variables.tf
+    main: terraform/azure-ai-model/provision/main.tf
+bind:
+  plan_inputs:
+  user_inputs:
+  computed_inputs:
+    - name: endpoint_url
+      type: string
+      default: ${instance.details["endpoint_url"]}
+      overwrite: true
+    - name: model_name
+      type: string
+      default: ${instance.details["model_name"]}
+      overwrite: true
+    - name: model_version
+      type: string
+      default: ${instance.details["model_version"]}
+      overwrite: true
+    - name: api_key
+      type: string
+      default: ${instance.details["api_key"]}
+      overwrite: true
+  outputs:
+    - field_name: model_name
+      type: string
+      details: The name of the AI model
+    - field_name: model_version
+      type: string
+      details: The version of the AI model
+    - field_name: api_key
+      type: string
+      details: The API key for accessing the AI model
+    - field_name: endpoint_url
+      type: string
+      details: The constructed endpoint URL for the AI model
+  template_refs:
+    outputs: terraform/azure-ai-model/bind/outputs.tf
+    variables: terraform/azure-ai-model/bind/variables.tf

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,40 +18,40 @@ version: 0.1.0
 metadata:
   author: VMware
 platforms:
-- os: linux
-  arch: amd64
+  - os: linux
+    arch: amd64
 # - os: darwin
 #   arch: amd64
 terraform_state_provider_replacements:
   registry.terraform.io/cloud-service-broker/csbsqlserver: "cloudfoundry.org/cloud-service-broker/csbsqlserver"
   registry.terraform.io/cloud-service-broker/csbmssqldbrunfailover: "cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover"
 terraform_upgrade_path:
-- version: 1.9.0
+  - version: 1.9.0
 terraform_binaries:
-- name: tofu
-  version: 1.9.0
-  source: https://github.com/opentofu/opentofu/archive/v1.9.0.zip
-  default: true
-- name: terraform-provider-azurerm
-  version: 3.117.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.117.0.zip
-- name: terraform-provider-random
-  version: 3.6.3
-  source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.3.zip
-- name: terraform-provider-csbsqlserver
-  version: 1.0.41
-  source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.41.zip
-  provider: cloudfoundry.org/cloud-service-broker/csbsqlserver
-  url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
-- name: terraform-provider-csbmssqldbrunfailover
-  version: 1.0.0
-  provider: cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover
-  url_template: ./providers/${name}/cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/${version}/${os}_${arch}/terraform-provider-csbmssqldbrunfailover_v${version}
-- name: terraform-provider-csbpg
-  version: 1.2.49
-  source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.2.49.zip
-  provider: cloudfoundry.org/cloud-service-broker/csbpg
-  url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+  - name: tofu
+    version: 1.9.0
+    source: https://github.com/opentofu/opentofu/archive/v1.9.0.zip
+    default: true
+  - name: terraform-provider-azurerm
+    version: 3.117.0
+    source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v3.117.0.zip
+  - name: terraform-provider-random
+    version: 3.6.3
+    source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.6.3.zip
+  - name: terraform-provider-csbsqlserver
+    version: 1.0.41
+    source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.41.zip
+    provider: cloudfoundry.org/cloud-service-broker/csbsqlserver
+    url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+  # - name: terraform-provider-csbmssqldbrunfailover
+  #   version: 1.0.0
+  #   provider: cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover
+  #   url_template: ./providers/${name}/cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/${version}/${os}_${arch}/terraform-provider-csbmssqldbrunfailover_v${version}
+  - name: terraform-provider-csbpg
+    version: 1.2.49
+    source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.2.49.zip
+    provider: cloudfoundry.org/cloud-service-broker/csbpg
+    url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 env_config_mapping:
   ARM_SUBSCRIPTION_ID: azure.subscription_id
   ARM_TENANT_ID: azure.tenant_id
@@ -60,8 +60,9 @@ env_config_mapping:
   MSSQL_DB_SERVER_CREDS: azure.mssql_db_server_creds
   MSSQL_DB_FOG_SERVER_PAIR_CREDS: azure.mssql_db_fog_server_pair_creds
 service_definitions:
-- azure-redis.yml
-- azure-mongodb.yml
-- azure-mssql-db.yml
-- azure-mssql-db-failover-group.yml
-- azure-mssql-fog-run-failover.yml
+  - azure-redis.yml
+  - azure-mongodb.yml
+  - azure-mssql-db.yml
+  # - azure-mssql-db-failover-group.yml
+  # - azure-mssql-fog-run-failover.yml
+  - azure-ai-model.yml

--- a/terraform/azure-ai-model/bind/outputs.tf
+++ b/terraform/azure-ai-model/bind/outputs.tf
@@ -1,0 +1,16 @@
+output "model_name" {
+  value = var.model_name
+}
+
+output "model_version" {
+  value = var.model_version
+}
+
+output "api_key" {
+  sensitive = true
+  value     = var.api_key
+}
+
+output "endpoint_url" {
+  value = var.endpoint_url
+}

--- a/terraform/azure-ai-model/bind/variables.tf
+++ b/terraform/azure-ai-model/bind/variables.tf
@@ -1,0 +1,18 @@
+variable "model_name" {
+  type        = string
+  description = "The name of the AI model."
+}
+
+variable "model_version" {
+  type        = string
+  description = "The version of the AI model."
+}
+
+variable "api_key" {
+  description = "The API key for accessing the AI model."
+  sensitive   = true
+}
+
+variable "endpoint_url" {
+  description = "The constructed endpoint URL for the AI model."
+}

--- a/terraform/azure-ai-model/provision/main.tf
+++ b/terraform/azure-ai-model/provision/main.tf
@@ -1,0 +1,40 @@
+# Based on this example: https://github.com/Azure/terraform-azurerm-avm-res-cognitiveservices-account/tree/main/examples/default
+
+# This ensures we have unique CAF compliant names for our resources.
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = ">= 0.3.0"
+}
+
+# This is required for resource modules
+resource "azurerm_resource_group" "this" {
+  location = var.location
+  name     = "avm-res-cognitiveservices-account-${module.naming.resource_group.name_unique}"
+}
+
+module "avm_res_cognitiveservices_account" {
+  source  = "Azure/avm-res-cognitiveservices-account/azurerm"
+  version = "0.6.0"
+
+  # Required configuration
+  kind                = "OpenAI"
+  location            = azurerm_resource_group.this.location
+  name                = "cloudgov-${module.naming.cognitive_account.name_unique}"
+  sku_name            = "S0"
+  resource_group_name = azurerm_resource_group.this.name
+
+  # Model configuration
+  cognitive_deployments = {
+    "instance" = {
+      name = var.model_name
+      model = {
+        format  = "OpenAI"
+        name    = var.model_name
+        version = var.model_version
+      }
+      scale = {
+        type = "Standard"
+      }
+    }
+  }
+}

--- a/terraform/azure-ai-model/provision/outputs.tf
+++ b/terraform/azure-ai-model/provision/outputs.tf
@@ -1,0 +1,27 @@
+output "service_name" {
+  description = "The name of the Azure AI service"
+  value       = module.avm_res_cognitiveservices_account.name
+}
+
+output "model_name" {
+  description = "The name of the AI model (deployment name)"
+  value       = var.model_name
+}
+
+output "model_version" {
+  description = "The version of the AI model"
+  value       = var.model_version
+}
+
+# The primary key from the Cognitive Services account
+output "api_key" {
+  description = "The API key for accessing the AI model"
+  value       = module.avm_res_cognitiveservices_account.primary_access_key
+  sensitive   = true
+}
+
+# Construct a model endpoint URL referencing the deployment name
+output "endpoint_url" {
+  description = "The constructed endpoint URL for the AI model"
+  value       = format("%s/openai/deployments/%s", module.avm_res_cognitiveservices_account.endpoint, var.model_name)
+}

--- a/terraform/azure-ai-model/provision/provider.tf
+++ b/terraform/azure-ai-model/provision/provider.tf
@@ -1,0 +1,8 @@
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.azure_subscription_id
+  tenant_id       = var.azure_tenant_id
+  client_id       = var.azure_client_id
+  client_secret   = var.azure_client_secret
+}

--- a/terraform/azure-ai-model/provision/variables.tf
+++ b/terraform/azure-ai-model/provision/variables.tf
@@ -1,0 +1,39 @@
+# Azure authentication
+variable "azure_tenant_id" {
+  type = string
+}
+
+variable "azure_subscription_id" {
+  type = string
+}
+
+variable "azure_client_id" {
+  type = string
+}
+
+variable "azure_client_secret" {
+  type = string
+}
+
+# User-provided service instance configuration
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
+variable "model_name" {
+  type        = string
+  description = "The name of the AI model."
+}
+
+variable "model_version" {
+  type        = string
+  default     = "latest"
+  description = "The version of the AI model."
+}
+
+# Computed variables
+variable "labels" {
+  type    = any
+  default = {}
+}

--- a/terraform/azure-ai-model/provision/versions.tf
+++ b/terraform/azure-ai-model/provision/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "< 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
- Mostly followed example here: https://github.com/Azure/terraform-azurerm-avm-res-cognitiveservices-account/tree/main/examples/default
- Corrected some mistakes in the service definition and documented user-specified fields, including models
- Added service definition to brokerpak manifest
- Fill in real GUIDs for the offering and plan IDs (thanks uuidgen)
- Commented out failing mssql services in the manifest, which are not necessary for this experiment
- Format code with Prettier (sorry, automatic)

I don't have Azure access to actually test this, but it passes `terraform validate` and `make build`, which itself runs `csb pak build`.

### Checklist:

(N/A for this experiment)

* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

