### PR TITLE
Fix module "file not found in zip" errors

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,38 +20,33 @@ metadata:
 platforms:
   - os: linux
     arch: amd64
-# - os: darwin
-#   arch: amd64
+  - os: darwin
+    arch: arm64
 terraform_state_provider_replacements:
   registry.terraform.io/cloud-service-broker/csbsqlserver: "cloudfoundry.org/cloud-service-broker/csbsqlserver"
   registry.terraform.io/cloud-service-broker/csbmssqldbrunfailover: "cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover"
 terraform_upgrade_path:
   - version: 1.9.0
 terraform_binaries:
-- name: tofu
-  version: 1.9.0
-  source: https://github.com/opentofu/opentofu/archive/v1.9.0.zip
-  default: true
-- name: terraform-provider-azurerm
-  version: 4.21.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v4.21.0.zip
-- name: terraform-provider-random
-  version: 3.7.1
-  source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.7.1.zip
-- name: terraform-provider-csbsqlserver
-  version: 1.0.41
-  source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.41.zip
-  provider: cloudfoundry.org/cloud-service-broker/csbsqlserver
-  url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
-# - name: terraform-provider-csbmssqldbrunfailover
-#   version: 1.0.0
-#   provider: cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover
-#   url_template: ./providers/${name}/cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/${version}/${os}_${arch}/terraform-provider-csbmssqldbrunfailover_v${version}
-- name: terraform-provider-csbpg
-  version: 1.2.49
-  source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.2.49.zip
-  provider: cloudfoundry.org/cloud-service-broker/csbpg
-  url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+  - name: tofu
+    version: 1.9.0
+    source: https://github.com/opentofu/opentofu/archive/v1.9.0.zip
+    default: true
+  - name: terraform-provider-azurerm
+    version: 4.21.0
+    source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v4.21.0.zip
+
+  - name: terraform-provider-random
+    version: 3.7.1
+    source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.7.1.zip
+  - name: terraform-provider-azapi
+    version: 2.2.0
+    source: https://github.com/Azure/terraform-provider-azapi/archive/refs/tags/v2.2.0.zip
+    url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+  - name: terraform-provider-modtm
+    version: 0.3.2
+    source: https://github.com/Azure/terraform-provider-modtm/archive/v0.3.2.zip
+    url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 env_config_mapping:
   ARM_SUBSCRIPTION_ID: azure.subscription_id
   ARM_TENANT_ID: azure.tenant_id
@@ -60,9 +55,4 @@ env_config_mapping:
   MSSQL_DB_SERVER_CREDS: azure.mssql_db_server_creds
   MSSQL_DB_FOG_SERVER_PAIR_CREDS: azure.mssql_db_fog_server_pair_creds
 service_definitions:
-  - azure-redis.yml
-  - azure-mongodb.yml
-  - azure-mssql-db.yml
-  # - azure-mssql-db-failover-group.yml
-  # - azure-mssql-fog-run-failover.yml
   - azure-ai-model.yml

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/.gitignore
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/.gitignore
@@ -1,0 +1,41 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Ignore Terraform lock file
+.terraform.lock.hcl
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+avmmakefile
+README-generated.md
+avm.tflint.hcl
+avm.tflint_example.hcl
+*tfplan*
+avm.tflint.merged.hcl
+avm.tflint_example.merged.hcl
+*.md.tmp
+.DS_Store
+avm.tflint_module.hcl
+avm.tflint_module.merged.hcl

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/CODE_OF_CONDUCT.md
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/LICENSE
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/Makefile
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/Makefile
@@ -1,0 +1,4 @@
+SHELL := /bin/bash
+
+$(shell curl -H 'Cache-Control: no-cache, no-store' -sSL "https://raw.githubusercontent.com/Azure/tfmod-scaffold/main/avmmakefile" -o avmmakefile)
+-include avmmakefile

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/README.md
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/README.md
@@ -1,0 +1,627 @@
+<!-- BEGIN_TF_DOCS -->
+# terraform-azurerm-avm-res-cognitiveservices-account
+
+This Terraform module is designed to manage Azure Cognitive Services. It provides a comprehensive set of variables and resources to configure and deploy Cognitive Services in Azure.
+
+> [!IMPORTANT]
+> As the overall AVM framework is not GA (generally available) yet - the CI framework and test automation is not fully functional and implemented across all supported languages yet - breaking changes are expected, and additional customer feedback is yet to be gathered and incorporated. Hence, modules **MUST NOT** be published at version `1.0.0` or higher at this time.
+>
+> All module **MUST** be published as a pre-release version (e.g., `0.1.0`, `0.1.1`, `0.2.0`, etc.) until the AVM framework becomes GA.
+>
+> However, it is important to note that this **DOES NOT** mean that the modules cannot be consumed and utilized. They **CAN** be leveraged in all types of environments (dev, test, prod etc.). Consumers can treat them just like any other IaC module and raise issues or feature requests against them as they learn from the usage of the module. Consumers should also read the release notes for each version, if considering updating to a more recent version of a module to see if there are any considerations or breaking changes etc.
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.3.0)
+
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.0)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
+
+- <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (>= 0.3.2, < 1.0)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (>= 3.5.0)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azapi_resource.rai_policy](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource) (resource)
+- [azurerm_ai_services.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/ai_services) (resource)
+- [azurerm_cognitive_account.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account) (resource)
+- [azurerm_cognitive_account_customer_managed_key.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_account_customer_managed_key) (resource)
+- [azurerm_cognitive_deployment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cognitive_deployment) (resource)
+- [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
+- [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
+- [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
+- [azurerm_private_endpoint.this_unmanaged_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
+- [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
+- [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
+- [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
+- [random_string.default_custom_subdomain_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
+- [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
+- [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
+- [azurerm_key_vault_key.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_key) (data source)
+- [azurerm_key_vault_managed_hardware_security_module_key.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_managed_hardware_security_module_key) (data source)
+- [azurerm_user_assigned_identity.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/user_assigned_identity) (data source)
+- [modtm_module_source.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/data-sources/module_source) (data source)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_kind"></a> [kind](#input\_kind)
+
+Description: (Optional) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `AIServices`,  `AnomalyDetector`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `CognitiveServices`, `ComputerVision`, `ContentModerator`, `ContentSafety`, `CustomSpeech`, `CustomVision.Prediction`, `CustomVision.Training`, `Emotion`, `Face`, `FormRecognizer`, `ImmersiveReader`, `LUIS`, `LUIS.Authoring`, `MetricsAdvisor`, `OpenAI`, `Personalizer`, `QnAMaker`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechServices`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created.
+
+Type: `string`
+
+### <a name="input_location"></a> [location](#input\_location)
+
+Description: (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+
+Type: `string`
+
+### <a name="input_name"></a> [name](#input\_name)
+
+Description: (Required) Specifies the name of the Cognitive Service or AI Service Account. Changing this forces a new resource to be created.
+
+Type: `string`
+
+### <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name)
+
+Description: (Required) The name of the resource group in which the Cognitive Service or AI Service Account is created. Changing this forces a new resource to be created.
+
+Type: `string`
+
+### <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name)
+
+Description: (Required) Specifies the SKU Name for this Cognitive Service or AI Service Account. Possible values are `F0`, `F1`, `S0`, `S`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1`, `P2`, `E0` and `DC0`.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_cognitive_deployments"></a> [cognitive\_deployments](#input\_cognitive\_deployments)
+
+Description: - `name` - (Required) The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
+- `rai_policy_name` - (Optional) The name of RAI policy.
+- `version_upgrade_option` - (Optional) Deployment model version upgrade option. Possible values are `OnceNewDefaultVersionAvailable`, `OnceCurrentVersionExpired`, and `NoAutoUpgrade`. Defaults to `OnceNewDefaultVersionAvailable`. Changing this forces a new resource to be created.
+
+---
+`model` block supports the following:
+- `format` - (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is `OpenAI`.
+- `name` - (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+- `version` - (Optional) The version of Cognitive Services Account Deployment model. If `version` is not specified, the default version of the model at the time will be assigned.
+
+---
+`scale` block supports the following:
+- `capacity` - (Optional) Tokens-per-Minute (TPM). The unit of measure for this field is in the thousands of Tokens-per-Minute. Defaults to `1` which means that the limitation is `1000` tokens per minute. If the resources SKU supports scale in/out then the capacity field should be included in the resources' configuration. If the scale in/out is not supported by the resources SKU then this field can be safely omitted. For more information about TPM please see the [product documentation](https://learn.microsoft.com/azure/ai-services/openai/how-to/quota?tabs=rest).
+- `family` - (Optional) If the service has different generations of hardware, for the same SKU, then that can be captured here. Changing this forces a new resource to be created.
+- `size` - (Optional) The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code. Changing this forces a new resource to be created.
+- `tier` - (Optional) Possible values are `Free`, `Basic`, `Standard`, `Premium`, `Enterprise`. Changing this forces a new resource to be created.
+- `type` - (Required) The name of the SKU. Ex
+
+---
+`timeouts` block supports the following:
+- `create` - (Defaults to 30 minutes) Used when creating the Cognitive Services Account Deployment.
+- `delete` - (Defaults to 30 minutes) Used when deleting the Cognitive Services Account Deployment.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Cognitive Services Account Deployment.
+- `update` - (Defaults to 30 minutes) Used when updating the Cognitive Services Account Deployment.
+
+Type:
+
+```hcl
+map(object({
+    name                   = string
+    rai_policy_name        = optional(string)
+    version_upgrade_option = optional(string)
+    model = object({
+      format  = string
+      name    = string
+      version = optional(string)
+    })
+    scale = object({
+      capacity = optional(number)
+      family   = optional(string)
+      size     = optional(string)
+      tier     = optional(string)
+      type     = string
+    })
+    timeouts = optional(object({
+      create = optional(string)
+      delete = optional(string)
+      read   = optional(string)
+      update = optional(string)
+    }))
+  }))
+```
+
+Default: `{}`
+
+### <a name="input_custom_question_answering_search_service_id"></a> [custom\_question\_answering\_search\_service\_id](#input\_custom\_question\_answering\_search\_service\_id)
+
+Description: (Optional) If `kind` is `TextAnalytics` this specifies the ID of the Search service.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_custom_question_answering_search_service_key"></a> [custom\_question\_answering\_search\_service\_key](#input\_custom\_question\_answering\_search\_service\_key)
+
+Description: (Optional) If `kind` is `TextAnalytics` this specifies the key of the Search service.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_custom_subdomain_name"></a> [custom\_subdomain\_name](#input\_custom\_subdomain\_name)
+
+Description: (Optional) The subdomain name used for token-based authentication. This property is required when `network_acls` is specified. Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_customer_managed_key"></a> [customer\_managed\_key](#input\_customer\_managed\_key)
+
+Description:   Controls the Customer managed key configuration on this resource. The following properties can be specified:
+
+  - `key_vault_resource_id` - (Required) Resource ID of the Key Vault that the customer managed key belongs to.
+  - `key_name` - (Required) Specifies the name of the Customer Managed Key Vault Key.
+  - `key_version` - (Optional) The version of the Customer Managed Key Vault Key.
+  - `user_assigned_identity` - (Optional) The User Assigned Identity that has access to the key.
+    - `resource_id` - (Required) The resource ID of the User Assigned Identity that has access to the key.
+
+Type:
+
+```hcl
+object({
+    key_vault_resource_id = string
+    key_name              = string
+    key_version           = optional(string, null)
+    user_assigned_identity = optional(object({
+      resource_id = string
+    }), null)
+  })
+```
+
+Default: `null`
+
+### <a name="input_diagnostic_settings"></a> [diagnostic\_settings](#input\_diagnostic\_settings)
+
+Description:   A map of diagnostic settings to create on the Cognitive Account. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+
+  - `name` - (Optional) The name of the diagnostic setting. One will be generated if not set, however this will not be unique if you want to create multiple diagnostic setting resources.
+  - `log_categories` - (Optional) A set of log categories to send to the log analytics workspace. Defaults to `[]`.
+  - `log_groups` - (Optional) A set of log groups to send to the log analytics workspace. Defaults to `["allLogs"]`.
+  - `metric_categories` - (Optional) A set of metric categories to send to the log analytics workspace. Defaults to `["AllMetrics"]`.
+  - `log_analytics_destination_type` - (Optional) The destination type for the diagnostic setting. Possible values are `Dedicated` and `AzureDiagnostics`. Defaults to `Dedicated`.
+  - `workspace_resource_id` - (Optional) The resource ID of the log analytics workspace to send logs and metrics to.
+  - `storage_account_resource_id` - (Optional) The resource ID of the storage account to send logs and metrics to.
+  - `event_hub_authorization_rule_resource_id` - (Optional) The resource ID of the event hub authorization rule to send logs and metrics to.
+  - `event_hub_name` - (Optional) The name of the event hub. If none is specified, the default event hub will be selected.
+  - `marketplace_partner_resource_id` - (Optional) The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic LogsLogs.
+
+Type:
+
+```hcl
+map(object({
+    name                                     = optional(string, null)
+    log_categories                           = optional(set(string), [])
+    log_groups                               = optional(set(string), ["allLogs"])
+    metric_categories                        = optional(set(string), ["AllMetrics"])
+    log_analytics_destination_type           = optional(string, "Dedicated")
+    workspace_resource_id                    = optional(string, null)
+    storage_account_resource_id              = optional(string, null)
+    event_hub_authorization_rule_resource_id = optional(string, null)
+    event_hub_name                           = optional(string, null)
+    marketplace_partner_resource_id          = optional(string, null)
+  }))
+```
+
+Default: `{}`
+
+### <a name="input_dynamic_throttling_enabled"></a> [dynamic\_throttling\_enabled](#input\_dynamic\_throttling\_enabled)
+
+Description: (Optional) Whether to enable the dynamic throttling for this Cognitive Service Account.
+
+Type: `bool`
+
+Default: `null`
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see https://aka.ms/avm/telemetryinfo.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_fqdns"></a> [fqdns](#input\_fqdns)
+
+Description: (Optional) List of FQDNs allowed for the Cognitive Account.
+
+Type: `list(string)`
+
+Default: `null`
+
+### <a name="input_is_hsm_key"></a> [is\_hsm\_key](#input\_is\_hsm\_key)
+
+Description: (Optional) Describes whether the Cognitive Account is using a Hardware Security Module (HSM) for encryption. Defaults to `false`.
+
+Type: `bool`
+
+Default: `false`
+
+### <a name="input_local_auth_enabled"></a> [local\_auth\_enabled](#input\_local\_auth\_enabled)
+
+Description: (Optional) Whether local authentication methods is enabled for the Cognitive Account. Defaults to `true`.
+
+Type: `bool`
+
+Default: `null`
+
+### <a name="input_lock"></a> [lock](#input\_lock)
+
+Description:   Controls the Resource Lock configuration for this resource. The following properties can be specified:
+
+  - `kind` - (Required) The type of lock. Possible values are `\"CanNotDelete\"` and `\"ReadOnly\"`.
+  - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
+
+Type:
+
+```hcl
+object({
+    kind = string
+    name = optional(string, null)
+  })
+```
+
+Default: `null`
+
+### <a name="input_managed_identities"></a> [managed\_identities](#input\_managed\_identities)
+
+Description:   Controls the Managed Identity configuration on this resource. The following properties can be specified:
+
+  - `system_assigned` - (Optional) Specifies if the System Assigned Managed Identity should be enabled.
+  - `user_assigned_resource_ids` - (Optional) Specifies a list of User Assigned Managed Identity resource IDs to be assigned to this resource.
+
+Type:
+
+```hcl
+object({
+    system_assigned            = optional(bool, false)
+    user_assigned_resource_ids = optional(set(string), [])
+  })
+```
+
+Default: `{}`
+
+### <a name="input_metrics_advisor_aad_client_id"></a> [metrics\_advisor\_aad\_client\_id](#input\_metrics\_advisor\_aad\_client\_id)
+
+Description: (Optional) The Azure AD Client ID (Application ID). This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_metrics_advisor_aad_tenant_id"></a> [metrics\_advisor\_aad\_tenant\_id](#input\_metrics\_advisor\_aad\_tenant\_id)
+
+Description: (Optional) The Azure AD Tenant ID. This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_metrics_advisor_super_user_name"></a> [metrics\_advisor\_super\_user\_name](#input\_metrics\_advisor\_super\_user\_name)
+
+Description: (Optional) The super user of Metrics Advisor. This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_metrics_advisor_website_name"></a> [metrics\_advisor\_website\_name](#input\_metrics\_advisor\_website\_name)
+
+Description: (Optional) The website name of Metrics Advisor. This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_network_acls"></a> [network\_acls](#input\_network\_acls)
+
+Description: - `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
+- `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Cognitive Account.
+
+---
+`virtual_network_rules` block supports the following:
+- `ignore_missing_vnet_service_endpoint` - (Optional) Whether ignore missing vnet service endpoint or not. Default to `false`.
+- `subnet_id` - (Required) The ID of the subnet which should be able to access this Cognitive Account.
+
+Type:
+
+```hcl
+object({
+    default_action = string
+    ip_rules       = optional(set(string))
+    virtual_network_rules = optional(set(object({
+      ignore_missing_vnet_service_endpoint = optional(bool)
+      subnet_id                            = string
+    })))
+  })
+```
+
+Default: `null`
+
+### <a name="input_outbound_network_access_restricted"></a> [outbound\_network\_access\_restricted](#input\_outbound\_network\_access\_restricted)
+
+Description: (Optional) Whether outbound network access is restricted for the Cognitive Account. Defaults to `false`.
+
+Type: `bool`
+
+Default: `null`
+
+### <a name="input_private_endpoints"></a> [private\_endpoints](#input\_private\_endpoints)
+
+Description:   A map of private endpoints to create on the Cognitive Service Account.
+
+  - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
+  - `role_assignments` - (Optional) A map of role assignments to create on the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time. See `var.role_assignments` for more information.
+  - `lock` - (Optional) The lock level to apply to the private endpoint. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
+  - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
+  - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
+  - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
+  - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
+  - `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set.
+  - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set.
+  - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the resource group.
+  - `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the Cognitive Services Account.
+  - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. If not specified the platform will create one. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+    - `name` - The name of the IP configuration.
+    - `private_ip_address` - The private IP address of the IP configuration.
+
+Type:
+
+```hcl
+map(object({
+    name = optional(string, null)
+    role_assignments = optional(map(object({
+      role_definition_id_or_name             = string
+      principal_id                           = string
+      description                            = optional(string, null)
+      skip_service_principal_aad_check       = optional(bool, false)
+      condition                              = optional(string, null)
+      condition_version                      = optional(string, null)
+      delegated_managed_identity_resource_id = optional(string, null)
+      principal_type                         = optional(string, null)
+    })), {})
+    lock = optional(object({
+      kind = string
+      name = optional(string, null)
+    }), null)
+    tags                                    = optional(map(string), null)
+    subnet_resource_id                      = string
+    private_dns_zone_group_name             = optional(string, "default")
+    private_dns_zone_resource_ids           = optional(set(string), [])
+    application_security_group_associations = optional(map(string), {})
+    private_service_connection_name         = optional(string, null)
+    network_interface_name                  = optional(string, null)
+    location                                = optional(string, null)
+    resource_group_name                     = optional(string, null)
+    ip_configurations = optional(map(object({
+      name               = string
+      private_ip_address = string
+    })), {})
+  }))
+```
+
+Default: `{}`
+
+### <a name="input_private_endpoints_manage_dns_zone_group"></a> [private\_endpoints\_manage\_dns\_zone\_group](#input\_private\_endpoints\_manage\_dns\_zone\_group)
+
+Description: Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled)
+
+Description: (Optional) Whether public network access is allowed for the Cognitive Account. Defaults to `true`.
+
+Type: `bool`
+
+Default: `true`
+
+### <a name="input_qna_runtime_endpoint"></a> [qna\_runtime\_endpoint](#input\_qna\_runtime\_endpoint)
+
+Description: (Optional) A URL to link a QnAMaker cognitive account to a QnA runtime.
+
+Type: `string`
+
+Default: `null`
+
+### <a name="input_rai_policies"></a> [rai\_policies](#input\_rai\_policies)
+
+Description: - `name` - (Required) The name of the RAI policy. Changing this forces a new resource to be created.
+- `base_policy_name` - (Required) The name of the base policy. Changing this forces a new resource to be created.
+- `mode` - Rai policy mode. The enum value mapping is as below: `Default`, `Deferred`, `Blocking`, `Asynchronous_filter`. Please use 'Asynchronous\_filter' after 2024-10-01. It is the same as 'Deferred' in previous version.
+
+---
+`content_filters` block supports the following:
+- `name` - (Required) Name of ContentFilter.
+- `enabled` - (Required) If the ContentFilter is enabled.
+- `severity_threshold` - (Required) Level at which content is filtered. Possible values are `Low`, `Medium`, `High`.
+- `blocking` - (Required) If blocking would occur.
+- `source` - (Required) Content source to apply the Content Filters. Possible values are `Prompt`, `Completion`.
+
+---
+`custom_block_lists` block supports the following:
+- `source` - (Required) Content source to apply the Custom Block Lists. Possible values are `Prompt`, `Completion`.
+- `block_list_name` - (Required) Name of ContentFilter.
+- `blocking` - (Required) If blocking would occur.
+
+Type:
+
+```hcl
+map(object({
+    name             = string
+    base_policy_name = string
+    mode             = string
+    content_filters = optional(list(object({
+      blocking           = bool
+      enabled            = bool
+      name               = string
+      severity_threshold = string
+      source             = string
+    })))
+    custom_block_lists = optional(list(object({
+      source          = string
+      block_list_name = string
+      blocking        = bool
+    })))
+  }))
+```
+
+Default: `{}`
+
+### <a name="input_role_assignments"></a> [role\_assignments](#input\_role\_assignments)
+
+Description:   A map of role assignments to create on the <RESOURCE>. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+
+  - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+  - `principal_id` - The ID of the principal to assign the role to.
+  - `description` - (Optional) The description of the role assignment.
+  - `skip_service_principal_aad_check` - (Optional) If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
+  - `condition` - (Optional) The condition which will be used to scope the role assignment.
+  - `condition_version` - (Optional) The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
+  - `delegated_managed_identity_resource_id` - (Optional) The delegated Azure Resource Id which contains a Managed Identity. Changing this forces a new resource to be created. This field is only used in cross-tenant scenario.
+  - `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+
+  > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+
+Type:
+
+```hcl
+map(object({
+    role_definition_id_or_name             = string
+    principal_id                           = string
+    description                            = optional(string, null)
+    skip_service_principal_aad_check       = optional(bool, false)
+    condition                              = optional(string, null)
+    condition_version                      = optional(string, null)
+    delegated_managed_identity_resource_id = optional(string, null)
+    principal_type                         = optional(string, null)
+  }))
+```
+
+Default: `{}`
+
+### <a name="input_storage"></a> [storage](#input\_storage)
+
+Description: - `identity_client_id` - (Optional) The client ID of the managed identity associated with the storage resource.
+- `storage_account_id` - (Required) Full resource id of a Microsoft.Storage resource.
+
+Type:
+
+```hcl
+list(object({
+    identity_client_id = optional(string)
+    storage_account_id = string
+  }))
+```
+
+Default: `null`
+
+### <a name="input_tags"></a> [tags](#input\_tags)
+
+Description: (Optional) A mapping of tags to assign to the resource.
+
+Type: `map(string)`
+
+Default: `null`
+
+### <a name="input_timeouts"></a> [timeouts](#input\_timeouts)
+
+Description: - `create` - (Defaults to 30 minutes) Used when creating the Cognitive Service or AI Service Account.
+- `delete` - (Defaults to 30 minutes) Used when deleting the Cognitive Service or AI Service Account.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Cognitive Service or AI Service Account.
+- `update` - (Defaults to 30 minutes) Used when updating the Cognitive Service or AI Service Account.
+
+Type:
+
+```hcl
+object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+```
+
+Default: `null`
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_endpoint"></a> [endpoint](#output\_endpoint)
+
+Description: The endpoint used to connect to the Cognitive Service Account.
+
+### <a name="output_name"></a> [name](#output\_name)
+
+Description: The name of cognitive account created.
+
+### <a name="output_primary_access_key"></a> [primary\_access\_key](#output\_primary\_access\_key)
+
+Description: A primary access key which can be used to connect to the Cognitive Service Account.
+
+### <a name="output_private_endpoints"></a> [private\_endpoints](#output\_private\_endpoints)
+
+Description:   A map of the private endpoints created.
+
+### <a name="output_rai_policy_id"></a> [rai\_policy\_id](#output\_rai\_policy\_id)
+
+Description: The ID of the RAI policy created.
+
+### <a name="output_resource"></a> [resource](#output\_resource)
+
+Description: The cognitive account resource created.
+
+### <a name="output_resource_cognitive_deployment"></a> [resource\_cognitive\_deployment](#output\_resource\_cognitive\_deployment)
+
+Description: The map of cognitive deployments created.
+
+### <a name="output_resource_id"></a> [resource\_id](#output\_resource\_id)
+
+Description: The resource ID of cognitive account created.
+
+### <a name="output_secondary_access_key"></a> [secondary\_access\_key](#output\_secondary\_access\_key)
+
+Description: A secondary access key which can be used to connect to the Cognitive Service Account.
+
+### <a name="output_system_assigned_mi_principal_id"></a> [system\_assigned\_mi\_principal\_id](#output\_system\_assigned\_mi\_principal\_id)
+
+Description: The principal ID of system assigned managed identity on the Cognitive/AI Service account created, when `var.managed_identities` is `null` or `var.managed_identities.system_assigned` is `false` this output is `null`.
+
+## Modules
+
+No modules.
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/SECURITY.md
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/SECURITY.md
@@ -1,0 +1,41 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V0.0.8 BLOCK -->
+
+## Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/opensource/security/definition), please report it to us as described below.
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/opensource/security/create-report).
+
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/opensource/security/pgpkey).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://aka.ms/opensource/security/msrc). 
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/opensource/security/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/opensource/security/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/SUPPORT.md
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/SUPPORT.md
@@ -1,0 +1,15 @@
+# Support
+
+> ⚠️**Note:** For the full details on the support statements, SLAs, and more for the Azure Verified Modules (AVM) initiative please visit [aka.ms/AVM/Support](https://aka.ms/avm/support) ⚠️
+
+## How to file issues and get help
+
+This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
+
+Issues can be created and searched through for existing [issues here](https://github.com/Azure/terraform-azurerm-avm-res-cognitiveservices-account/issues).
+
+Please provide as much information as possible when filing an issue. Include screenshots or correlation IDs if possible (please redact any sensitive information).
+
+For instructions on how to get deployments and correlation ID, please follow this link [here](https://learn.microsoft.com/azure/azure-resource-manager/templates/deployment-history?tabs=azure-portal#get-deployments-and-correlation-id).
+
+We may ask you to create an Azure support request once we have triaged the issue following the process documented [here](https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request).

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/_footer.md
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/_header.md
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/_header.md
@@ -1,0 +1,10 @@
+# terraform-azurerm-avm-res-cognitiveservices-account
+
+This Terraform module is designed to manage Azure Cognitive Services. It provides a comprehensive set of variables and resources to configure and deploy Cognitive Services in Azure.
+
+> [!IMPORTANT]
+> As the overall AVM framework is not GA (generally available) yet - the CI framework and test automation is not fully functional and implemented across all supported languages yet - breaking changes are expected, and additional customer feedback is yet to be gathered and incorporated. Hence, modules **MUST NOT** be published at version `1.0.0` or higher at this time.
+> 
+> All module **MUST** be published as a pre-release version (e.g., `0.1.0`, `0.1.1`, `0.2.0`, etc.) until the AVM framework becomes GA.
+> 
+> However, it is important to note that this **DOES NOT** mean that the modules cannot be consumed and utilized. They **CAN** be leveraged in all types of environments (dev, test, prod etc.). Consumers can treat them just like any other IaC module and raise issues or feature requests against them as they learn from the usage of the module. Consumers should also read the release notes for each version, if considering updating to a more recent version of a module to see if there are any considerations or breaking changes etc.

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/diagnostic.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/diagnostic.tf
@@ -1,0 +1,34 @@
+resource "azurerm_monitor_diagnostic_setting" "this" {
+  for_each = var.diagnostic_settings
+
+  name                           = coalesce(each.value.name, "diag-${var.name}")
+  target_resource_id             = local.resource_block.id
+  eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
+  eventhub_name                  = each.value.event_hub_name
+  log_analytics_destination_type = each.value.log_analytics_destination_type
+  log_analytics_workspace_id     = each.value.workspace_resource_id
+  partner_solution_id            = each.value.marketplace_partner_resource_id
+  storage_account_id             = each.value.storage_account_resource_id
+
+  dynamic "enabled_log" {
+    for_each = each.value.log_categories
+
+    content {
+      category = enabled_log.value
+    }
+  }
+  dynamic "enabled_log" {
+    for_each = each.value.log_groups
+
+    content {
+      category_group = enabled_log.value
+    }
+  }
+  dynamic "metric" {
+    for_each = each.value.metric_categories
+
+    content {
+      category = metric.value
+    }
+  }
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/lock.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/lock.tf
@@ -1,0 +1,8 @@
+resource "azurerm_management_lock" "this" {
+  count = var.lock != null ? 1 : 0
+
+  lock_level = var.lock.kind
+  name       = coalesce(var.lock.name, "lock-${var.lock.kind}")
+  scope      = local.resource_block.id
+  notes      = var.lock.kind == "CanNotDelete" ? "Cannot delete the resource or its child resources." : "Cannot delete or modify the resource or its child resources."
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.aiservies.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.aiservies.tf
@@ -1,0 +1,74 @@
+resource "azurerm_ai_services" "this" {
+  count = var.kind == "AIServices" ? 1 : 0
+
+  location                           = var.location
+  name                               = var.name
+  resource_group_name                = var.resource_group_name
+  sku_name                           = var.sku_name
+  custom_subdomain_name              = var.custom_subdomain_name
+  fqdns                              = var.fqdns
+  local_authentication_enabled       = var.local_auth_enabled
+  outbound_network_access_restricted = var.outbound_network_access_restricted
+  public_network_access              = var.public_network_access_enabled ? "Enabled" : "Disabled"
+  tags                               = var.tags
+
+  dynamic "customer_managed_key" {
+    for_each = var.is_hsm_key && var.customer_managed_key != null ? [1] : []
+
+    content {
+      identity_client_id = local.managed_key_identity_client_id
+      # we'll leave the regular key to `azurerm_cognitive_account_customer_managed_key` resource
+      managed_hsm_key_id = try(data.azurerm_key_vault_managed_hardware_security_module_key.this[0].versioned_id, null)
+    }
+  }
+  dynamic "identity" {
+    for_each = (var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0) ? { this = var.managed_identities } : {}
+
+    content {
+      type         = identity.value.system_assigned && length(identity.value.user_assigned_resource_ids) > 0 ? "SystemAssigned, UserAssigned" : length(identity.value.user_assigned_resource_ids) > 0 ? "UserAssigned" : "SystemAssigned"
+      identity_ids = identity.value.user_assigned_resource_ids
+    }
+  }
+  dynamic "network_acls" {
+    for_each = var.network_acls == null ? [] : [var.network_acls]
+
+    content {
+      default_action = network_acls.value.default_action
+      ip_rules       = network_acls.value.ip_rules
+
+      dynamic "virtual_network_rules" {
+        for_each = network_acls.value.virtual_network_rules == null ? [] : network_acls.value.virtual_network_rules
+
+        content {
+          subnet_id                            = virtual_network_rules.value.subnet_id
+          ignore_missing_vnet_service_endpoint = virtual_network_rules.value.ignore_missing_vnet_service_endpoint
+        }
+      }
+    }
+  }
+  dynamic "storage" {
+    for_each = var.storage == null ? [] : var.storage
+
+    content {
+      storage_account_id = storage.value.storage_account_id
+      identity_client_id = storage.value.identity_client_id
+    }
+  }
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = try(!var.is_hsm_key || can(regex("^\\/subscriptions\\/([a-fA-F0-9\\-]{36})\\/resourceGroups\\/([a-zA-Z0-9\\-]+)\\/providers\\/Microsoft\\.KeyVault\\/managedHSMs\\/([a-zA-Z0-9\\-]+)$", var.customer_managed_key.key_vault_resource_id)), true)
+      error_message = "When `var.is_hardware_security_module == true`, then the provided key vault resource ID must be managed HSM"
+    }
+  }
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.privateendpoint.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.privateendpoint.tf
@@ -1,0 +1,86 @@
+resource "azurerm_private_endpoint" "this" {
+  for_each = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
+
+  location                      = each.value.location != null ? each.value.location : var.location
+  name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
+  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
+  subnet_id                     = each.value.subnet_resource_id
+  custom_network_interface_name = each.value.network_interface_name
+  tags                          = each.value.tags
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
+    private_connection_resource_id = local.resource_block.id
+    subresource_names              = ["account"] # map to each.value.subresource_name if there are multiple services.
+  }
+  dynamic "ip_configuration" {
+    for_each = each.value.ip_configurations
+
+    content {
+      name               = ip_configuration.value.name
+      private_ip_address = ip_configuration.value.private_ip_address
+      member_name        = "account" # map to each.value.subresource_name if there are multiple services.
+      subresource_name   = "account" # map to each.value.subresource_name if there are multiple services.
+    }
+  }
+  dynamic "private_dns_zone_group" {
+    for_each = length(each.value.private_dns_zone_resource_ids) > 0 ? ["this"] : []
+
+    content {
+      name                 = each.value.private_dns_zone_group_name
+      private_dns_zone_ids = each.value.private_dns_zone_resource_ids
+    }
+  }
+}
+
+resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
+  for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
+
+  location                      = each.value.location != null ? each.value.location : var.location
+  name                          = each.value.name != null ? each.value.name : "pep-${var.name}"
+  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
+  subnet_id                     = each.value.subnet_resource_id
+  custom_network_interface_name = each.value.network_interface_name
+  tags                          = each.value.tags
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}"
+    private_connection_resource_id = local.resource_block.id
+    subresource_names              = ["account"] # map to each.value.subresource_name if there are multiple services.
+  }
+  dynamic "ip_configuration" {
+    for_each = each.value.ip_configurations
+
+    content {
+      name               = ip_configuration.value.name
+      private_ip_address = ip_configuration.value.private_ip_address
+      member_name        = "account" # map to each.value.subresource_name if there are multiple services.
+      subresource_name   = "account" # map to each.value.subresource_name if there are multiple services.
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [private_dns_zone_group]
+  }
+}
+
+locals {
+  private_endpoint_application_security_group_associations = { for assoc in flatten([
+    for pe_k, pe_v in var.private_endpoints : [
+      for asg_k, asg_v in pe_v.application_security_group_associations : {
+        asg_key         = asg_k
+        pe_key          = pe_k
+        asg_resource_id = asg_v
+      }
+    ]
+  ]) : "${assoc.pe_key}-${assoc.asg_key}" => assoc }
+}
+
+resource "azurerm_private_endpoint_application_security_group_association" "this" {
+  for_each = local.private_endpoint_application_security_group_associations
+
+  application_security_group_id = each.value.asg_resource_id
+  private_endpoint_id           = azurerm_private_endpoint.this[each.value.pe_key].id
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.rai_policy.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.rai_policy.tf
@@ -1,0 +1,25 @@
+resource "azapi_resource" "rai_policy" {
+  for_each = var.rai_policies
+
+  type = "Microsoft.CognitiveServices/accounts/raiPolicies@2024-10-01"
+  body = {
+    properties = {
+      basePolicyName = each.value.base_policy_name
+      mode           = each.value.mode
+      contentFilters = try([for c in each.value.content_filters : {
+        blocking          = c.blocking
+        enabled           = c.enabled
+        name              = c.name
+        severityThreshold = c.severity_threshold
+        source            = c.source
+      }], null)
+      customBlocklists = try([for c in each.value.custom_block_lists : {
+        source        = c.source
+        blocklistName = c.block_list_name
+        blocking      = c.blocking
+      }], null)
+    }
+  }
+  name      = each.value.name
+  parent_id = local.resource_block.id
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.telemetry.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.telemetry.tf
@@ -1,0 +1,25 @@
+data "azurerm_client_config" "telemetry" {
+  count = var.enable_telemetry ? 1 : 0
+}
+
+data "modtm_module_source" "telemetry" {
+  count = var.enable_telemetry ? 1 : 0
+
+  module_path = path.module
+}
+
+resource "random_uuid" "telemetry" {
+  count = var.enable_telemetry ? 1 : 0
+}
+
+resource "modtm_telemetry" "telemetry" {
+  count = var.enable_telemetry ? 1 : 0
+
+  tags = {
+    subscription_id = one(data.azurerm_client_config.telemetry).subscription_id
+    tenant_id       = one(data.azurerm_client_config.telemetry).tenant_id
+    module_source   = one(data.modtm_module_source.telemetry).module_source
+    module_version  = one(data.modtm_module_source.telemetry).module_version
+    random_id       = one(random_uuid.telemetry).result
+  }
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main.tf
@@ -1,0 +1,191 @@
+moved {
+  from = random_string.default_custom_subdomain_name_suffix
+  to   = random_string.default_custom_subdomain_name_suffix[0]
+}
+
+resource "random_string" "default_custom_subdomain_name_suffix" {
+  count = var.kind != "AIServices" ? 1 : 0
+
+  length  = 5
+  special = false
+  upper   = false
+}
+
+moved {
+  from = azurerm_cognitive_account.this
+  to   = azurerm_cognitive_account.this[0]
+}
+
+resource "azurerm_cognitive_account" "this" {
+  count = var.kind != "AIServices" ? 1 : 0
+
+  kind                                         = var.kind
+  location                                     = var.location
+  name                                         = var.name
+  resource_group_name                          = var.resource_group_name
+  sku_name                                     = var.sku_name
+  custom_question_answering_search_service_id  = var.custom_question_answering_search_service_id
+  custom_question_answering_search_service_key = var.custom_question_answering_search_service_key
+  custom_subdomain_name                        = coalesce(var.custom_subdomain_name, "azure-cognitive-${random_string.default_custom_subdomain_name_suffix[0].result}")
+  dynamic_throttling_enabled                   = var.dynamic_throttling_enabled
+  fqdns                                        = var.fqdns
+  local_auth_enabled                           = var.local_auth_enabled
+  metrics_advisor_aad_client_id                = var.metrics_advisor_aad_client_id
+  metrics_advisor_aad_tenant_id                = var.metrics_advisor_aad_tenant_id
+  metrics_advisor_super_user_name              = var.metrics_advisor_super_user_name
+  metrics_advisor_website_name                 = var.metrics_advisor_website_name
+  outbound_network_access_restricted           = var.outbound_network_access_restricted
+  public_network_access_enabled                = var.public_network_access_enabled
+  qna_runtime_endpoint                         = var.qna_runtime_endpoint
+  tags                                         = var.tags
+
+  dynamic "identity" {
+    for_each = (var.managed_identities.system_assigned || length(var.managed_identities.user_assigned_resource_ids) > 0) ? { this = var.managed_identities } : {}
+
+    content {
+      type         = identity.value.system_assigned && length(identity.value.user_assigned_resource_ids) > 0 ? "SystemAssigned, UserAssigned" : length(identity.value.user_assigned_resource_ids) > 0 ? "UserAssigned" : "SystemAssigned"
+      identity_ids = identity.value.user_assigned_resource_ids
+    }
+  }
+  dynamic "network_acls" {
+    for_each = var.network_acls == null ? [] : [var.network_acls]
+
+    content {
+      default_action = network_acls.value.default_action
+      ip_rules       = network_acls.value.ip_rules
+
+      dynamic "virtual_network_rules" {
+        for_each = network_acls.value.virtual_network_rules == null ? [] : network_acls.value.virtual_network_rules
+
+        content {
+          subnet_id                            = virtual_network_rules.value.subnet_id
+          ignore_missing_vnet_service_endpoint = virtual_network_rules.value.ignore_missing_vnet_service_endpoint
+        }
+      }
+    }
+  }
+  dynamic "storage" {
+    for_each = var.storage == null ? [] : var.storage
+
+    content {
+      storage_account_id = storage.value.storage_account_id
+      identity_client_id = storage.value.identity_client_id
+    }
+  }
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      customer_managed_key,
+    ]
+
+    precondition {
+      # we cannot add this check on `azurerm_cognitive_account_customer_managed_key` resource, since when `var.is_hsm_key` is `false` the resource won't be created.
+      condition     = var.kind == "AIServices" || !var.is_hsm_key
+      error_message = "HSM key could only be used when `var.kind == \"AIServices\"`"
+    }
+  }
+}
+
+locals {
+  managed_key_identity_client_id = try(data.azurerm_user_assigned_identity.this[0].client_id, null)
+}
+
+data "azurerm_key_vault_key" "this" {
+  count = var.customer_managed_key != null && !var.is_hsm_key ? 1 : 0
+
+  key_vault_id = var.customer_managed_key.key_vault_resource_id
+  name         = var.customer_managed_key.key_name
+}
+
+data "azurerm_key_vault_managed_hardware_security_module_key" "this" {
+  count = var.customer_managed_key != null && var.is_hsm_key ? 1 : 0
+
+  managed_hsm_id = var.customer_managed_key.key_vault_resource_id
+  name           = var.customer_managed_key.key_name
+}
+
+data "azurerm_user_assigned_identity" "this" {
+  count = try(var.customer_managed_key.user_assigned_identity != null, false) ? 1 : 0
+
+  #/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}
+  name                = reverse(split("/", var.customer_managed_key.user_assigned_identity.resource_id))[0]
+  resource_group_name = split("/", var.customer_managed_key.user_assigned_identity.resource_id)[4]
+}
+
+resource "azurerm_cognitive_account_customer_managed_key" "this" {
+  count = var.customer_managed_key != null && !var.is_hsm_key ? 1 : 0
+
+  cognitive_account_id = local.resource_block.id
+  key_vault_key_id     = data.azurerm_key_vault_key.this[0].id
+  identity_client_id   = local.managed_key_identity_client_id
+
+  dynamic "timeouts" {
+    for_each = var.timeouts == null ? [] : [var.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+}
+
+resource "azurerm_cognitive_deployment" "this" {
+  for_each = var.cognitive_deployments
+
+  cognitive_account_id   = local.resource_block.id
+  name                   = each.value.name
+  rai_policy_name        = each.value.rai_policy_name
+  version_upgrade_option = each.value.version_upgrade_option
+
+  dynamic "model" {
+    for_each = [each.value.model]
+
+    content {
+      format  = model.value.format
+      name    = model.value.name
+      version = model.value.version
+    }
+  }
+  dynamic "sku" {
+    for_each = [each.value.scale]
+    iterator = scale
+
+    content {
+      capacity = scale.value.capacity
+      family   = scale.value.family
+      name     = scale.value.type
+      size     = scale.value.size
+      tier     = scale.value.tier
+    }
+  }
+  dynamic "timeouts" {
+    for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+      update = timeouts.value.update
+    }
+  }
+
+  depends_on = [
+    azurerm_cognitive_account_customer_managed_key.this
+  ]
+}
+
+locals {
+  resource_block = try(azurerm_cognitive_account.this[0], azurerm_ai_services.this[0])
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main_role_assignments.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/main_role_assignments.tf
@@ -1,0 +1,17 @@
+locals {
+  role_definition_resource_substring = "Cognitive Services"
+}
+
+resource "azurerm_role_assignment" "this" {
+  for_each = var.role_assignments
+
+  principal_id                           = each.value.principal_id
+  scope                                  = local.resource_block.id
+  condition                              = each.value.condition
+  condition_version                      = each.value.condition_version
+  delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id
+  principal_type                         = each.value.principal_type
+  role_definition_id                     = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_definition_id_or_name
+  role_definition_name                   = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_definition_id_or_name : null
+  skip_service_principal_aad_check       = each.value.skip_service_principal_aad_check
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/outputs.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/outputs.tf
@@ -1,0 +1,53 @@
+output "endpoint" {
+  description = "The endpoint used to connect to the Cognitive Service Account."
+  value       = local.resource_block.endpoint
+}
+
+output "name" {
+  description = "The name of cognitive account created."
+  value       = local.resource_block.name
+}
+
+output "primary_access_key" {
+  description = "A primary access key which can be used to connect to the Cognitive Service Account."
+  sensitive   = true
+  value       = local.resource_block.primary_access_key
+}
+
+output "private_endpoints" {
+  description = <<DESCRIPTION
+  A map of the private endpoints created.
+  DESCRIPTION
+  value       = azurerm_private_endpoint.this
+}
+
+output "rai_policy_id" {
+  description = "The ID of the RAI policy created."
+  value       = { for k, v in azapi_resource.rai_policy : k => v.id }
+}
+
+output "resource" {
+  description = "The cognitive account resource created."
+  value       = local.resource_block
+}
+
+output "resource_cognitive_deployment" {
+  description = "The map of cognitive deployments created."
+  value       = azurerm_cognitive_deployment.this
+}
+
+output "resource_id" {
+  description = "The resource ID of cognitive account created."
+  value       = local.resource_block.id
+}
+
+output "secondary_access_key" {
+  description = "A secondary access key which can be used to connect to the Cognitive Service Account."
+  sensitive   = true
+  value       = local.resource_block.secondary_access_key
+}
+
+output "system_assigned_mi_principal_id" {
+  description = "The principal ID of system assigned managed identity on the Cognitive/AI Service account created, when `var.managed_identities` is `null` or `var.managed_identities.system_assigned` is `false` this output is `null`."
+  value       = try(var.managed_identities.system_assigned, false) ? local.resource_block.identity[0].principal_id : null
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/terraform.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/terraform.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    modtm = {
+      source  = "Azure/modtm"
+      version = ">= 0.3.2, < 1.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.0"
+    }
+  }
+}

--- a/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/variables.tf
+++ b/terraform/azure-ai-model/provision/azurerm-avm-res-cognitiveservices-account/variables.tf
@@ -1,0 +1,466 @@
+variable "kind" {
+  type        = string
+  description = "(Optional) Specifies the type of Cognitive Service Account that should be created. Possible values are `Academic`, `AIServices`,  `AnomalyDetector`, `Bing.Autosuggest`, `Bing.Autosuggest.v7`, `Bing.CustomSearch`, `Bing.Search`, `Bing.Search.v7`, `Bing.Speech`, `Bing.SpellCheck`, `Bing.SpellCheck.v7`, `CognitiveServices`, `ComputerVision`, `ContentModerator`, `ContentSafety`, `CustomSpeech`, `CustomVision.Prediction`, `CustomVision.Training`, `Emotion`, `Face`, `FormRecognizer`, `ImmersiveReader`, `LUIS`, `LUIS.Authoring`, `MetricsAdvisor`, `OpenAI`, `Personalizer`, `QnAMaker`, `Recommendations`, `SpeakerRecognition`, `Speech`, `SpeechServices`, `SpeechTranslation`, `TextAnalytics`, `TextTranslation` and `WebLM`. Changing this forces a new resource to be created."
+  nullable    = false
+}
+
+variable "location" {
+  type        = string
+  description = "(Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created."
+  nullable    = false
+}
+
+variable "name" {
+  type        = string
+  description = "(Required) Specifies the name of the Cognitive Service or AI Service Account. Changing this forces a new resource to be created."
+  nullable    = false
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "(Required) The name of the resource group in which the Cognitive Service or AI Service Account is created. Changing this forces a new resource to be created."
+  nullable    = false
+}
+
+variable "sku_name" {
+  type        = string
+  description = "(Required) Specifies the SKU Name for this Cognitive Service or AI Service Account. Possible values are `F0`, `F1`, `S0`, `S`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1`, `P2`, `E0` and `DC0`."
+  nullable    = false
+}
+
+variable "cognitive_deployments" {
+  type = map(object({
+    name                   = string
+    rai_policy_name        = optional(string)
+    version_upgrade_option = optional(string)
+    model = object({
+      format  = string
+      name    = string
+      version = optional(string)
+    })
+    scale = object({
+      capacity = optional(number)
+      family   = optional(string)
+      size     = optional(string)
+      tier     = optional(string)
+      type     = string
+    })
+    timeouts = optional(object({
+      create = optional(string)
+      delete = optional(string)
+      read   = optional(string)
+      update = optional(string)
+    }))
+  }))
+  default     = {}
+  description = <<-DESCRIPTION
+ - `name` - (Required) The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
+ - `rai_policy_name` - (Optional) The name of RAI policy.
+ - `version_upgrade_option` - (Optional) Deployment model version upgrade option. Possible values are `OnceNewDefaultVersionAvailable`, `OnceCurrentVersionExpired`, and `NoAutoUpgrade`. Defaults to `OnceNewDefaultVersionAvailable`. Changing this forces a new resource to be created.
+
+ ---
+ `model` block supports the following:
+ - `format` - (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is `OpenAI`.
+ - `name` - (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+ - `version` - (Optional) The version of Cognitive Services Account Deployment model. If `version` is not specified, the default version of the model at the time will be assigned.
+
+ ---
+ `scale` block supports the following:
+ - `capacity` - (Optional) Tokens-per-Minute (TPM). The unit of measure for this field is in the thousands of Tokens-per-Minute. Defaults to `1` which means that the limitation is `1000` tokens per minute. If the resources SKU supports scale in/out then the capacity field should be included in the resources' configuration. If the scale in/out is not supported by the resources SKU then this field can be safely omitted. For more information about TPM please see the [product documentation](https://learn.microsoft.com/azure/ai-services/openai/how-to/quota?tabs=rest).
+ - `family` - (Optional) If the service has different generations of hardware, for the same SKU, then that can be captured here. Changing this forces a new resource to be created.
+ - `size` - (Optional) The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code. Changing this forces a new resource to be created.
+ - `tier` - (Optional) Possible values are `Free`, `Basic`, `Standard`, `Premium`, `Enterprise`. Changing this forces a new resource to be created.
+ - `type` - (Required) The name of the SKU. Ex
+
+ ---
+ `timeouts` block supports the following:
+ - `create` - (Defaults to 30 minutes) Used when creating the Cognitive Services Account Deployment.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Cognitive Services Account Deployment.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Cognitive Services Account Deployment.
+ - `update` - (Defaults to 30 minutes) Used when updating the Cognitive Services Account Deployment.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "custom_question_answering_search_service_id" {
+  type        = string
+  default     = null
+  description = "(Optional) If `kind` is `TextAnalytics` this specifies the ID of the Search service."
+}
+
+variable "custom_question_answering_search_service_key" {
+  type        = string
+  default     = null
+  description = "(Optional) If `kind` is `TextAnalytics` this specifies the key of the Search service."
+  sensitive   = true
+}
+
+variable "custom_subdomain_name" {
+  type        = string
+  default     = null
+  description = "(Optional) The subdomain name used for token-based authentication. This property is required when `network_acls` is specified. Changing this forces a new resource to be created."
+}
+
+variable "customer_managed_key" {
+  type = object({
+    key_vault_resource_id = string
+    key_name              = string
+    key_version           = optional(string, null)
+    user_assigned_identity = optional(object({
+      resource_id = string
+    }), null)
+  })
+  default     = null
+  description = <<DESCRIPTION
+  Controls the Customer managed key configuration on this resource. The following properties can be specified:
+
+  - `key_vault_resource_id` - (Required) Resource ID of the Key Vault that the customer managed key belongs to.
+  - `key_name` - (Required) Specifies the name of the Customer Managed Key Vault Key.
+  - `key_version` - (Optional) The version of the Customer Managed Key Vault Key.
+  - `user_assigned_identity` - (Optional) The User Assigned Identity that has access to the key.
+    - `resource_id` - (Required) The resource ID of the User Assigned Identity that has access to the key.
+  DESCRIPTION
+}
+
+variable "diagnostic_settings" {
+  type = map(object({
+    name                                     = optional(string, null)
+    log_categories                           = optional(set(string), [])
+    log_groups                               = optional(set(string), ["allLogs"])
+    metric_categories                        = optional(set(string), ["AllMetrics"])
+    log_analytics_destination_type           = optional(string, "Dedicated")
+    workspace_resource_id                    = optional(string, null)
+    storage_account_resource_id              = optional(string, null)
+    event_hub_authorization_rule_resource_id = optional(string, null)
+    event_hub_name                           = optional(string, null)
+    marketplace_partner_resource_id          = optional(string, null)
+  }))
+  default     = {}
+  description = <<DESCRIPTION
+  A map of diagnostic settings to create on the Cognitive Account. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+
+  - `name` - (Optional) The name of the diagnostic setting. One will be generated if not set, however this will not be unique if you want to create multiple diagnostic setting resources.
+  - `log_categories` - (Optional) A set of log categories to send to the log analytics workspace. Defaults to `[]`.
+  - `log_groups` - (Optional) A set of log groups to send to the log analytics workspace. Defaults to `["allLogs"]`.
+  - `metric_categories` - (Optional) A set of metric categories to send to the log analytics workspace. Defaults to `["AllMetrics"]`.
+  - `log_analytics_destination_type` - (Optional) The destination type for the diagnostic setting. Possible values are `Dedicated` and `AzureDiagnostics`. Defaults to `Dedicated`.
+  - `workspace_resource_id` - (Optional) The resource ID of the log analytics workspace to send logs and metrics to.
+  - `storage_account_resource_id` - (Optional) The resource ID of the storage account to send logs and metrics to.
+  - `event_hub_authorization_rule_resource_id` - (Optional) The resource ID of the event hub authorization rule to send logs and metrics to.
+  - `event_hub_name` - (Optional) The name of the event hub. If none is specified, the default event hub will be selected.
+  - `marketplace_partner_resource_id` - (Optional) The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic LogsLogs.
+  DESCRIPTION
+  nullable    = false
+
+  validation {
+    condition     = alltrue([for _, v in var.diagnostic_settings : contains(["Dedicated", "AzureDiagnostics"], v.log_analytics_destination_type)])
+    error_message = "Log analytics destination type must be one of: 'Dedicated', 'AzureDiagnostics'."
+  }
+  validation {
+    condition = alltrue(
+      [
+        for _, v in var.diagnostic_settings :
+        v.workspace_resource_id != null || v.storage_account_resource_id != null || v.event_hub_authorization_rule_resource_id != null || v.marketplace_partner_resource_id != null
+      ]
+    )
+    error_message = "At least one of `workspace_resource_id`, `storage_account_resource_id`, `marketplace_partner_resource_id`, or `event_hub_authorization_rule_resource_id`, must be set."
+  }
+}
+
+variable "dynamic_throttling_enabled" {
+  type        = bool
+  default     = null
+  description = "(Optional) Whether to enable the dynamic throttling for this Cognitive Service Account."
+}
+
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see https://aka.ms/avm/telemetryinfo.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}
+
+variable "fqdns" {
+  type        = list(string)
+  default     = null
+  description = "(Optional) List of FQDNs allowed for the Cognitive Account."
+}
+
+variable "is_hsm_key" {
+  type        = bool
+  default     = false
+  description = "(Optional) Describes whether the Cognitive Account is using a Hardware Security Module (HSM) for encryption. Defaults to `false`."
+  nullable    = false
+}
+
+variable "local_auth_enabled" {
+  type        = bool
+  default     = null
+  description = "(Optional) Whether local authentication methods is enabled for the Cognitive Account. Defaults to `true`."
+}
+
+variable "lock" {
+  type = object({
+    kind = string
+    name = optional(string, null)
+  })
+  default     = null
+  description = <<DESCRIPTION
+  Controls the Resource Lock configuration for this resource. The following properties can be specified:
+
+  - `kind` - (Required) The type of lock. Possible values are `\"CanNotDelete\"` and `\"ReadOnly\"`.
+  - `name` - (Optional) The name of the lock. If not specified, a name will be generated based on the `kind` value. Changing this forces the creation of a new resource.
+  DESCRIPTION
+
+  validation {
+    condition     = var.lock != null ? contains(["CanNotDelete", "ReadOnly"], var.lock.kind) : true
+    error_message = "Lock kind must be either `\"CanNotDelete\"` or `\"ReadOnly\"`."
+  }
+}
+
+variable "managed_identities" {
+  type = object({
+    system_assigned            = optional(bool, false)
+    user_assigned_resource_ids = optional(set(string), [])
+  })
+  default     = {}
+  description = <<DESCRIPTION
+  Controls the Managed Identity configuration on this resource. The following properties can be specified:
+
+  - `system_assigned` - (Optional) Specifies if the System Assigned Managed Identity should be enabled.
+  - `user_assigned_resource_ids` - (Optional) Specifies a list of User Assigned Managed Identity resource IDs to be assigned to this resource.
+  DESCRIPTION
+  nullable    = false
+}
+
+variable "metrics_advisor_aad_client_id" {
+  type        = string
+  default     = null
+  description = "(Optional) The Azure AD Client ID (Application ID). This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created."
+}
+
+variable "metrics_advisor_aad_tenant_id" {
+  type        = string
+  default     = null
+  description = "(Optional) The Azure AD Tenant ID. This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created."
+}
+
+variable "metrics_advisor_super_user_name" {
+  type        = string
+  default     = null
+  description = "(Optional) The super user of Metrics Advisor. This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created."
+}
+
+variable "metrics_advisor_website_name" {
+  type        = string
+  default     = null
+  description = "(Optional) The website name of Metrics Advisor. This attribute is only set when kind is `MetricsAdvisor`. Changing this forces a new resource to be created."
+}
+
+variable "network_acls" {
+  type = object({
+    default_action = string
+    ip_rules       = optional(set(string))
+    virtual_network_rules = optional(set(object({
+      ignore_missing_vnet_service_endpoint = optional(bool)
+      subnet_id                            = string
+    })))
+  })
+  default     = null
+  description = <<-DESCRIPTION
+ - `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_rules`. Possible values are `Allow` and `Deny`.
+ - `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Cognitive Account.
+
+ ---
+ `virtual_network_rules` block supports the following:
+ - `ignore_missing_vnet_service_endpoint` - (Optional) Whether ignore missing vnet service endpoint or not. Default to `false`.
+ - `subnet_id` - (Required) The ID of the subnet which should be able to access this Cognitive Account.
+DESCRIPTION
+}
+
+variable "outbound_network_access_restricted" {
+  type        = bool
+  default     = null
+  description = "(Optional) Whether outbound network access is restricted for the Cognitive Account. Defaults to `false`."
+}
+
+variable "private_endpoints" {
+  type = map(object({
+    name = optional(string, null)
+    role_assignments = optional(map(object({
+      role_definition_id_or_name             = string
+      principal_id                           = string
+      description                            = optional(string, null)
+      skip_service_principal_aad_check       = optional(bool, false)
+      condition                              = optional(string, null)
+      condition_version                      = optional(string, null)
+      delegated_managed_identity_resource_id = optional(string, null)
+      principal_type                         = optional(string, null)
+    })), {})
+    lock = optional(object({
+      kind = string
+      name = optional(string, null)
+    }), null)
+    tags                                    = optional(map(string), null)
+    subnet_resource_id                      = string
+    private_dns_zone_group_name             = optional(string, "default")
+    private_dns_zone_resource_ids           = optional(set(string), [])
+    application_security_group_associations = optional(map(string), {})
+    private_service_connection_name         = optional(string, null)
+    network_interface_name                  = optional(string, null)
+    location                                = optional(string, null)
+    resource_group_name                     = optional(string, null)
+    ip_configurations = optional(map(object({
+      name               = string
+      private_ip_address = string
+    })), {})
+  }))
+  default     = {}
+  description = <<DESCRIPTION
+  A map of private endpoints to create on the Cognitive Service Account.
+  
+  - `name` - (Optional) The name of the private endpoint. One will be generated if not set.
+  - `role_assignments` - (Optional) A map of role assignments to create on the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time. See `var.role_assignments` for more information.
+  - `lock` - (Optional) The lock level to apply to the private endpoint. Default is `None`. Possible values are `None`, `CanNotDelete`, and `ReadOnly`.
+  - `tags` - (Optional) A mapping of tags to assign to the private endpoint.
+  - `subnet_resource_id` - The resource ID of the subnet to deploy the private endpoint in.
+  - `private_dns_zone_group_name` - (Optional) The name of the private DNS zone group. One will be generated if not set.
+  - `private_dns_zone_resource_ids` - (Optional) A set of resource IDs of private DNS zones to associate with the private endpoint. If not set, no zone groups will be created and the private endpoint will not be associated with any private DNS zones. DNS records must be managed external to this module.
+  - `application_security_group_resource_ids` - (Optional) A map of resource IDs of application security groups to associate with the private endpoint. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set.
+  - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set.
+  - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the resource group.
+  - `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the Cognitive Services Account.
+  - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. If not specified the platform will create one. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+    - `name` - The name of the IP configuration.
+    - `private_ip_address` - The private IP address of the IP configuration.
+  DESCRIPTION
+  nullable    = false
+}
+
+variable "private_endpoints_manage_dns_zone_group" {
+  type        = bool
+  default     = true
+  description = "Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy."
+  nullable    = false
+}
+
+variable "public_network_access_enabled" {
+  type        = bool
+  default     = true
+  description = "(Optional) Whether public network access is allowed for the Cognitive Account. Defaults to `true`."
+  nullable    = false
+}
+
+variable "qna_runtime_endpoint" {
+  type        = string
+  default     = null
+  description = "(Optional) A URL to link a QnAMaker cognitive account to a QnA runtime."
+}
+
+variable "rai_policies" {
+  type = map(object({
+    name             = string
+    base_policy_name = string
+    mode             = string
+    content_filters = optional(list(object({
+      blocking           = bool
+      enabled            = bool
+      name               = string
+      severity_threshold = string
+      source             = string
+    })))
+    custom_block_lists = optional(list(object({
+      source          = string
+      block_list_name = string
+      blocking        = bool
+    })))
+  }))
+  default     = {}
+  description = <<-DESCRIPTION
+ - `name` - (Required) The name of the RAI policy. Changing this forces a new resource to be created.
+ - `base_policy_name` - (Required) The name of the base policy. Changing this forces a new resource to be created.
+ - `mode` - Rai policy mode. The enum value mapping is as below: `Default`, `Deferred`, `Blocking`, `Asynchronous_filter`. Please use 'Asynchronous_filter' after 2024-10-01. It is the same as 'Deferred' in previous version.
+
+ ---
+ `content_filters` block supports the following:
+ - `name` - (Required) Name of ContentFilter.
+ - `enabled` - (Required) If the ContentFilter is enabled.
+ - `severity_threshold` - (Required) Level at which content is filtered. Possible values are `Low`, `Medium`, `High`.
+ - `blocking` - (Required) If blocking would occur.
+ - `source` - (Required) Content source to apply the Content Filters. Possible values are `Prompt`, `Completion`.
+
+ ---
+ `custom_block_lists` block supports the following:
+ - `source` - (Required) Content source to apply the Custom Block Lists. Possible values are `Prompt`, `Completion`.
+ - `block_list_name` - (Required) Name of ContentFilter.
+ - `blocking` - (Required) If blocking would occur.
+DESCRIPTION
+  nullable    = false
+}
+
+variable "role_assignments" {
+  type = map(object({
+    role_definition_id_or_name             = string
+    principal_id                           = string
+    description                            = optional(string, null)
+    skip_service_principal_aad_check       = optional(bool, false)
+    condition                              = optional(string, null)
+    condition_version                      = optional(string, null)
+    delegated_managed_identity_resource_id = optional(string, null)
+    principal_type                         = optional(string, null)
+  }))
+  default     = {}
+  description = <<DESCRIPTION
+  A map of role assignments to create on the <RESOURCE>. The map key is deliberately arbitrary to avoid issues where map keys maybe unknown at plan time.
+  
+  - `role_definition_id_or_name` - The ID or name of the role definition to assign to the principal.
+  - `principal_id` - The ID of the principal to assign the role to.
+  - `description` - (Optional) The description of the role assignment.
+  - `skip_service_principal_aad_check` - (Optional) If set to true, skips the Azure Active Directory check for the service principal in the tenant. Defaults to false.
+  - `condition` - (Optional) The condition which will be used to scope the role assignment.
+  - `condition_version` - (Optional) The version of the condition syntax. Leave as `null` if you are not using a condition, if you are then valid values are '2.0'.
+  - `delegated_managed_identity_resource_id` - (Optional) The delegated Azure Resource Id which contains a Managed Identity. Changing this forces a new resource to be created. This field is only used in cross-tenant scenario.
+  - `principal_type` - (Optional) The type of the `principal_id`. Possible values are `User`, `Group` and `ServicePrincipal`. It is necessary to explicitly set this attribute when creating role assignments if the principal creating the assignment is constrained by ABAC rules that filters on the PrincipalType attribute.
+  
+  > Note: only set `skip_service_principal_aad_check` to true if you are assigning a role to a service principal.
+  DESCRIPTION
+  nullable    = false
+}
+
+variable "storage" {
+  type = list(object({
+    identity_client_id = optional(string)
+    storage_account_id = string
+  }))
+  default     = null
+  description = <<-DESCRIPTION
+ - `identity_client_id` - (Optional) The client ID of the managed identity associated with the storage resource.
+ - `storage_account_id` - (Required) Full resource id of a Microsoft.Storage resource.
+DESCRIPTION
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = null
+  description = "(Optional) A mapping of tags to assign to the resource."
+}
+
+variable "timeouts" {
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    read   = optional(string)
+    update = optional(string)
+  })
+  default     = null
+  description = <<-DESCRIPTION
+ - `create` - (Defaults to 30 minutes) Used when creating the Cognitive Service or AI Service Account.
+ - `delete` - (Defaults to 30 minutes) Used when deleting the Cognitive Service or AI Service Account.
+ - `read` - (Defaults to 5 minutes) Used when retrieving the Cognitive Service or AI Service Account.
+ - `update` - (Defaults to 30 minutes) Used when updating the Cognitive Service or AI Service Account.
+DESCRIPTION
+}

--- a/terraform/azure-ai-model/provision/main.tf
+++ b/terraform/azure-ai-model/provision/main.tf
@@ -2,8 +2,7 @@
 
 # This ensures we have unique CAF compliant names for our resources.
 module "naming" {
-  source  = "Azure/naming/azurerm"
-  version = ">= 0.3.0"
+  source = "./azurerm-naming"
 }
 
 # This is required for resource modules
@@ -13,8 +12,7 @@ resource "azurerm_resource_group" "this" {
 }
 
 module "avm_res_cognitiveservices_account" {
-  source  = "Azure/avm-res-cognitiveservices-account/azurerm"
-  version = "0.6.0"
+  source = "./azurerm-avm-res-cognitiveservices-account"
 
   # Required configuration
   kind                = "OpenAI"


### PR DESCRIPTION
I got the following error trying to load the brokerpak into the CSB: `panic: error loading brokerpaks: file with prefix "bin/linux/amd64/Azure/naming/azurerm" not found in zip`

I believe the CSB does not understand how to pull and package *modules* from the registry. (It can pull providers just fine.) To temporarily solve this, I have vendored the Azure `naming` and `avm-res-cognitiveservices-account` modules into the provisioning code. I confirmed my local CSB now loads the brokerpak correctly.

The modules are MIT-licensed, so vendoring and modifying them is fine as long as the license is reproduced here. (It is preserved in each directory.)

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

