### PR TITLE
fix(build): First fully-working Azure OpenAI brokerpak version

### DIFF
--- a/azure-ai-model.yml
+++ b/azure-ai-model.yml
@@ -60,6 +60,9 @@ provision:
       type: string
       details: Client secret for Azure principal
       default: ${config("azure.client_secret")}
+    - name: instance_id
+      type: string
+      default: ${request.instance_id}
   outputs:
     - field_name: service_name
       type: string

--- a/azure-ai-model.yml
+++ b/azure-ai-model.yml
@@ -21,24 +21,19 @@ provision:
   user_inputs:
     - field_name: location
       type: string
-      default: eastus
-      details: The region to create the service in
+      default: eastus2
+      details: The Azure region to create the service in.
       constraints:
         pattern: "^[a-zA-Z0-9-]+$"
     - field_name: model_name
       type: string
-      details: The name of the AI model. Valid options are `o1-preview`, `o1-mini`, `gpt-4o`, `gpt-4o-mini`. The full list of models that are supported by Azure (but not necessarily supported yet by this brokerpak) is found in the [Azure Documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models).
+      details: The name of the AI model. Valid options are `o1-preview`, `o1-mini`, `gpt-4o`, `gpt-4o-mini`. The full list of models that are supported by Azure (but not necessarily supported yet by this brokerpak) is found in the [Azure Documentation](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#global-standard-model-availability).
       required: true
     - field_name: model_version
       type: string
       default: latest
       details: |
-        The version of the AI model. The default is `latest`. Valid versions for each model are:
-
-        - `o1-preview`: `2024-09-12`
-        - `o1-mini`: `2024-09-12`
-        - `gpt-4o`: `2024-11-20`, `2024-08-06`, `2024-05-13`
-        - `gpt-4o-mini`: `2024-07-18`
+        The version of the AI model. Valid versions for each model are: <ul><li>`o1-preview`: `2024-09-12`</li><li>`o1-mini`: `2024-09-12`</li><li>`gpt-4o`: `2024-11-20`, `2024-08-06`, `2024-05-13`</li><li>`gpt-4o-mini`: `2024-07-18`</li></ul>Not all versions are available in all regions. See the [Azure Global standard model availability](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#global-standard-model-availability) table.
   computed_inputs:
     - name: labels
       default: ${json.marshal(request.default_labels)}

--- a/azure-ai-model.yml
+++ b/azure-ai-model.yml
@@ -16,9 +16,6 @@ plans:
     id: d9575f01-1d5b-4196-bea8-e0d59b6ccfd9
     description: "Basic plan for Azure AI Model"
     display_name: "Basic"
-    properties:
-      model_name: "default-model"
-      model_version: "latest"
 provision:
   plan_inputs:
   user_inputs:
@@ -36,7 +33,7 @@ provision:
       type: string
       default: latest
       details: |
-        The version of the AI model. Valid versions for each model are:
+        The version of the AI model. The default is `latest`. Valid versions for each model are:
 
         - `o1-preview`: `2024-09-12`
         - `o1-mini`: `2024-09-12`

--- a/manifest.yml
+++ b/manifest.yml
@@ -44,10 +44,12 @@ terraform_binaries:
   - name: terraform-provider-azapi
     version: 2.2.0
     source: https://github.com/Azure/terraform-provider-azapi/archive/refs/tags/v2.2.0.zip
+    provider: registry.terraform.io/Azure/azapi
     url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
   - name: terraform-provider-modtm
     version: 0.3.2
     source: https://github.com/Azure/terraform-provider-modtm/archive/v0.3.2.zip
+    provider: registry.terraform.io/Azure/modtm
     url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 env_config_mapping:
   ARM_SUBSCRIPTION_ID: azure.subscription_id

--- a/manifest.yml
+++ b/manifest.yml
@@ -26,7 +26,6 @@ terraform_state_provider_replacements:
   registry.opentofu.org/hashicorp/random: "registry.terraform.io/hashicorp/random"
   registry.opentofu.org/hashicorp/azurerm: "registry.terraform.io/hashicorp/azurerm"
   registry.opentofu.org/Azure/azapi: "registry.terraform.io/Azure/azapi"
-  registry.opentofu.org/Azure/modtm: "registry.terraform.io/Azure/modtm"
 terraform_upgrade_path:
   - version: 1.8.2
 terraform_binaries:
@@ -41,16 +40,6 @@ terraform_binaries:
   - name: terraform-provider-random
     version: 3.7.1
     source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.7.1.zip
-  - name: terraform-provider-azapi
-    version: 2.2.0
-    source: https://github.com/Azure/terraform-provider-azapi/archive/refs/tags/v2.2.0.zip
-    provider: registry.terraform.io/Azure/azapi
-    url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
-  - name: terraform-provider-modtm
-    version: 0.3.2
-    source: https://github.com/Azure/terraform-provider-modtm/archive/v0.3.2.zip
-    provider: registry.terraform.io/Azure/modtm
-    url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 env_config_mapping:
   ARM_SUBSCRIPTION_ID: azure.subscription_id
   ARM_TENANT_ID: azure.tenant_id

--- a/manifest.yml
+++ b/manifest.yml
@@ -20,49 +20,39 @@ metadata:
 platforms:
   - os: linux
     arch: amd64
-# - os: darwin
-#   arch: amd64
+  - os: darwin
+    arch: arm64
 terraform_state_provider_replacements:
-  registry.terraform.io/cloud-service-broker/csbsqlserver: "cloudfoundry.org/cloud-service-broker/csbsqlserver"
-  registry.terraform.io/cloud-service-broker/csbmssqldbrunfailover: "cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover"
+  registry.opentofu.org/hashicorp/random: "registry.terraform.io/hashicorp/random"
+  registry.opentofu.org/hashicorp/azurerm: "registry.terraform.io/hashicorp/azurerm"
+  registry.opentofu.org/Azure/azapi: "registry.terraform.io/Azure/azapi"
+  registry.opentofu.org/Azure/modtm: "registry.terraform.io/Azure/modtm"
 terraform_upgrade_path:
-  - version: 1.9.0
+  - version: 1.8.2
 terraform_binaries:
-- name: tofu
-  version: 1.9.0
-  source: https://github.com/opentofu/opentofu/archive/v1.9.0.zip
-  default: true
-- name: terraform-provider-azurerm
-  version: 4.21.0
-  source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v4.21.0.zip
-- name: terraform-provider-random
-  version: 3.7.1
-  source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.7.1.zip
-- name: terraform-provider-csbsqlserver
-  version: 1.0.41
-  source: https://github.com/cloudfoundry/terraform-provider-csbsqlserver/archive/v1.0.41.zip
-  provider: cloudfoundry.org/cloud-service-broker/csbsqlserver
-  url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
-# - name: terraform-provider-csbmssqldbrunfailover
-#   version: 1.0.0
-#   provider: cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover
-#   url_template: ./providers/${name}/cloudfoundry.org/cloud-service-broker/csbmssqldbrunfailover/${version}/${os}_${arch}/terraform-provider-csbmssqldbrunfailover_v${version}
-- name: terraform-provider-csbpg
-  version: 1.2.49
-  source: https://github.com/cloudfoundry/terraform-provider-csbpg/archive/v1.2.49.zip
-  provider: cloudfoundry.org/cloud-service-broker/csbpg
-  url_template: https://github.com/cloudfoundry/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+  - name: tofu
+    version: 1.8.2
+    source: https://github.com/opentofu/opentofu/archive/v1.8.2.zip
+    url_template: https://github.com/opentofu/opentofu/releases/download/v${version}/tofu_${version}_${os}_${arch}.zip
+    default: true
+  - name: terraform-provider-azurerm
+    version: 4.21.0
+    source: https://github.com/terraform-providers/terraform-provider-azurerm/archive/v4.21.0.zip
+  - name: terraform-provider-random
+    version: 3.7.1
+    source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.7.1.zip
+  - name: terraform-provider-azapi
+    version: 2.2.0
+    source: https://github.com/Azure/terraform-provider-azapi/archive/refs/tags/v2.2.0.zip
+    url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+  - name: terraform-provider-modtm
+    version: 0.3.2
+    source: https://github.com/Azure/terraform-provider-modtm/archive/v0.3.2.zip
+    url_template: https://github.com/Azure/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
 env_config_mapping:
   ARM_SUBSCRIPTION_ID: azure.subscription_id
   ARM_TENANT_ID: azure.tenant_id
   ARM_CLIENT_ID: azure.client_id
   ARM_CLIENT_SECRET: azure.client_secret
-  MSSQL_DB_SERVER_CREDS: azure.mssql_db_server_creds
-  MSSQL_DB_FOG_SERVER_PAIR_CREDS: azure.mssql_db_fog_server_pair_creds
 service_definitions:
-  - azure-redis.yml
-  - azure-mongodb.yml
-  - azure-mssql-db.yml
-  # - azure-mssql-db-failover-group.yml
-  # - azure-mssql-fog-run-failover.yml
   - azure-ai-model.yml

--- a/scripts/clientconfig.yml
+++ b/scripts/clientconfig.yml
@@ -1,0 +1,4 @@
+api:
+  user: broker
+  password: FC_2@8r_LcwufyqQiwc@9TE
+  port: 8081

--- a/scripts/clientconfig.yml
+++ b/scripts/clientconfig.yml
@@ -1,4 +1,4 @@
 api:
   user: broker
-  password: FC_2@8r_LcwufyqQiwc@9TE
+  password: local-development
   port: 8081

--- a/scripts/down.sh
+++ b/scripts/down.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eo pipefail
+
+# Work around the broker not having a command like `csb client list` by tracking the
+# instances and bindings we've created.
+
+if [ "$#" -lt 1 ]; then
+  printf "Usage:\n\n\t\$./down.sh /path/to/workdir\n\nWorking directory must match the directory passed to up.sh."
+  exit 1
+fi
+
+workdir=$1
+
+cat "${workdir}/bindings.txt" | xargs -n 2 bash -c 'cloud-service-broker client unbind --config clientconfig.yml --planid 35ffb84b-a898-442e-b5f9-0a6a5229827d --serviceid 260f2ead-b9e9-48b5-9a01-6e3097208ad7 --instanceid $1 --bindingid $2' -
+echo "\n\n$(date)" >> bindings.txt.history
+cat ${workdir}/bindings.txt >> ${workdir}/bindings.txt.history
+rm ${workdir}/bindings.txt
+
+cat "${workdir}/instances.txt" | xargs -I % cloud-service-broker client deprovision --config clientconfig.yml --planid 35ffb84b-a898-442e-b5f9-0a6a5229827d --serviceid 260f2ead-b9e9-48b5-9a01-6e3097208ad7 --instanceid %
+echo "\n$(date)" >> instances.txt.history
+cat ${workdir}/instances.txt >> ${workdir}/instances.txt.history
+rm ${workdir}/instances.txt
+
+echo "Done. instances.txt and bindings.txt cleared. History recorded in instances.txt.history and bindings.txt.history."
+

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eo pipefail
+
+if [ "$#" -lt 1 ]; then
+  printf "Usage:\n\n\t\$./up.sh /path/to/workdir\n\n"
+  exit 1
+fi
+
+workdir=$1
+
+csb=cloud-service-broker
+planid=d9575f01-1d5b-4196-bea8-e0d59b6ccfd9
+serviceid=2b89aa85-00c8-4507-a74b-c8f7ce95bf27
+
+# Instance IDs must be unique, so generate a new one
+instanceid=$(uuidgen | tr "[A-Z]" "[a-z]")
+echo "Instance ID: $instanceid"
+
+# Start provisioning
+$csb client provision --config clientconfig.yml --planid $planid --serviceid $serviceid --instanceid $instanceid --params "{\"model_name\": \"gpt-4o\", \"model_version\": \"2024-11-20\"}"
+
+# Wait on provisioning to finish
+state=""
+while [[ "$state" != "succeeded" ]]; do
+	sleep 10
+	state=$($csb client --config clientconfig.yml last --instanceid $instanceid | jq -r '.response.state')
+	echo "State: $state"
+done
+
+touch "$workdir/instances.txt"
+echo $instanceid >> "$workdir/instances.txt"
+
+# Let the broker settle
+sleep 1
+
+# Binding IDs must be unique, so generate a new one
+bindingid=$(uuidgen | tr "[A-Z]" "[a-z]")
+echo "Binding ID: $bindingid"
+touch "$workdir/bindings.txt"
+echo "$instanceid $bindingid" >> "$workdir/bindings.txt"
+
+# Update smtp-client with new credentials
+$csb client bind --config clientconfig.yml --planid $planid --serviceid $serviceid --instanceid $instanceid --bindingid $bindingid | jq '.response.credentials' > "$workdir/credentials.json"
+
+echo "Done. Credentials saved to credentials.json for use with the client. GUIDs saved to instances.txt and bindings.txt. Deprovision later with down.sh."

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -17,7 +17,7 @@ instanceid=$(uuidgen | tr "[A-Z]" "[a-z]")
 echo "Instance ID: $instanceid"
 
 # Start provisioning
-$csb client provision --config clientconfig.yml --planid $planid --serviceid $serviceid --instanceid $instanceid --params "{\"model_name\": \"gpt-4o\", \"model_version\": \"2024-11-20\"}"
+$csb client provision --config clientconfig.yml --planid $planid --serviceid $serviceid --instanceid $instanceid --params "{\"model_name\": \"gpt-4o\", \"model_version\": \"2024-08-06\"}"
 
 # Wait on provisioning to finish
 state=""

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -39,7 +39,7 @@ echo "Binding ID: $bindingid"
 touch "$workdir/bindings.txt"
 echo "$instanceid $bindingid" >> "$workdir/bindings.txt"
 
-# Update smtp-client with new credentials
+# Record new credentials for client testing
 $csb client bind --config clientconfig.yml --planid $planid --serviceid $serviceid --instanceid $instanceid --bindingid $bindingid | jq '.response.credentials' > "$workdir/credentials.json"
 
 echo "Done. Credentials saved to credentials.json for use with the client. GUIDs saved to instances.txt and bindings.txt. Deprovision later with down.sh."

--- a/terraform/azure-ai-model/provision/main.tf
+++ b/terraform/azure-ai-model/provision/main.tf
@@ -1,40 +1,29 @@
 # Based on this example: https://github.com/Azure/terraform-azurerm-avm-res-cognitiveservices-account/tree/main/examples/default
 
-# This ensures we have unique CAF compliant names for our resources.
-module "naming" {
-  source  = "Azure/naming/azurerm"
-  version = ">= 0.3.0"
-}
-
 # This is required for resource modules
 resource "azurerm_resource_group" "this" {
   location = var.location
-  name     = "avm-res-cognitiveservices-account-${module.naming.resource_group.name_unique}"
+  name     = "rg-cloudgov-azureai-${var.instance_id}"
 }
 
-module "avm_res_cognitiveservices_account" {
-  source  = "Azure/avm-res-cognitiveservices-account/azurerm"
-  version = "0.6.0"
-
-  # Required configuration
+resource "azurerm_cognitive_account" "this" {
   kind                = "OpenAI"
   location            = azurerm_resource_group.this.location
-  name                = "cloudgov-${module.naming.cognitive_account.name_unique}"
+  name                = "cog-cloudgov-azureai-${var.instance_id}"
   sku_name            = "S0"
   resource_group_name = azurerm_resource_group.this.name
+}
 
-  # Model configuration
-  cognitive_deployments = {
-    "instance" = {
-      name = var.model_name
-      model = {
-        format  = "OpenAI"
-        name    = var.model_name
-        version = var.model_version
-      }
-      scale = {
-        type = "Standard"
-      }
-    }
+resource "azurerm_cognitive_deployment" "this" {
+  cognitive_account_id = azurerm_cognitive_account.this.id
+  name                 = "cog-cloudgov-azureai-${var.instance_id}-${var.model_name}"
+
+  model {
+    name    = var.model_name
+    format  = "OpenAI"
+    version = var.model_version
+  }
+  sku {
+    name = "Standard"
   }
 }

--- a/terraform/azure-ai-model/provision/outputs.tf
+++ b/terraform/azure-ai-model/provision/outputs.tf
@@ -1,6 +1,6 @@
 output "service_name" {
   description = "The name of the Azure AI service"
-  value       = module.avm_res_cognitiveservices_account.name
+  value       = azurerm_cognitive_deployment.this.name
 }
 
 output "model_name" {
@@ -16,12 +16,12 @@ output "model_version" {
 # The primary key from the Cognitive Services account
 output "api_key" {
   description = "The API key for accessing the AI model"
-  value       = module.avm_res_cognitiveservices_account.primary_access_key
+  value       = azurerm_cognitive_account.this.primary_access_key
   sensitive   = true
 }
 
 # Construct a model endpoint URL referencing the deployment name
 output "endpoint_url" {
   description = "The constructed endpoint URL for the AI model"
-  value       = format("%sopenai/deployments/%s", module.avm_res_cognitiveservices_account.endpoint, var.model_name)
+  value       = format("%sopenai/deployments/%s", azurerm_cognitive_account.this.endpoint, var.model_name)
 }

--- a/terraform/azure-ai-model/provision/provider.tf
+++ b/terraform/azure-ai-model/provision/provider.tf
@@ -6,3 +6,6 @@ provider "azurerm" {
   client_id       = var.azure_client_id
   client_secret   = var.azure_client_secret
 }
+
+provider "random" {
+}

--- a/terraform/azure-ai-model/provision/variables.tf
+++ b/terraform/azure-ai-model/provision/variables.tf
@@ -37,3 +37,8 @@ variable "labels" {
   type    = any
   default = {}
 }
+
+variable "instance_id" {
+  type        = string
+  description = "The GUID of the service instance being provisioned."
+}

--- a/terraform/azure-ai-model/provision/versions.tf
+++ b/terraform/azure-ai-model/provision/versions.tf
@@ -3,8 +3,17 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
+      source  = "registry.terraform.io/hashicorp/azurerm"
       version = "< 5.0.0"
+    }
+    random = {
+      source = "registry.terraform.io/hashicorp/random"
+    }
+    azapi = {
+      source = "registry.terraform.io/Azure/azapi"
+    }
+    modtm = {
+      source = "registry.terraform.io/Azure/modtm"
     }
   }
 }

--- a/terraform/azure-ai-model/provision/versions.tf
+++ b/terraform/azure-ai-model/provision/versions.tf
@@ -9,11 +9,5 @@ terraform {
     random = {
       source = "registry.terraform.io/hashicorp/random"
     }
-    azapi = {
-      source = "registry.terraform.io/Azure/azapi"
-    }
-    modtm = {
-      source = "registry.terraform.io/Azure/modtm"
-    }
   }
 }


### PR DESCRIPTION
Changes: 

- Inline the necessary resources from the Azure Naming and Cognitive Services modules. Remote modules that require providers from the Terraform registry rather than the OpenTofu registry are not currently compatible with the CSB. It uses OpenTofu and will try pulling providers from the Tofu registry, but the CSB itself is actually only compatible with Terraform (not OpenTofu) providers. Full discussion [here](https://gsa-tts.slack.com/archives/C08EWJVHUQL/p1741057482301769?thread_ts=1741019913.587769&cid=C08EWJVHUQL).
- Drop `properties` from the plan in the service definition; having them set here prevents the user from configuring them.
- Support local development workflow with `darwin/arm64` binaries and a few scripts for spinning up service instances. Borrowed from github.com/cloud-gov/csb
- Fully qualify all provider names to force downloading from the Terraform registry
- Drop unused providers

### Checklist:

* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

